### PR TITLE
fix: add an action to remove any existing tf folders

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -59,6 +59,9 @@ components:
         before:
           - cmd: "tofu init -backend=false"
             dir: ./s3-irsa
+      onDeploy:
+        before:
+          - cmd: rm -rf ./s3-irsa || true
     files:
       - source: ./s3-irsa/
         target: ./s3-irsa/


### PR DESCRIPTION
Add an action to remove existing tf folders. Previously this would cause issues on re-deploys where the folder already existed.