### PR TITLE
updates and fixes for uds-core velero

### DIFF
--- a/s3-irsa/main.tf
+++ b/s3-irsa/main.tf
@@ -31,7 +31,7 @@ locals {
       irsa_policy_name           = "loki-irsa-policy"
     }
     "velero" = {
-      kubernetes_service_account = "velero-velero-server"
+      kubernetes_service_account = "velero-server"
       kubernetes_namespace       = "velero"
       irsa_iam_role_name         = "velero-irsa-role"
       irsa_policy_name           = "velero-irsa-policy"
@@ -220,7 +220,7 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
         ]
         Effect = "Allow"
         Principal = {
-          AWS = aws_iam_role.irsa[0].arn
+          AWS = aws_iam_role.irsa[count.index].arn
         }
         Resource = [
           module.s3_bucket[count.index].s3_bucket_arn,


### PR DESCRIPTION
Fixed the service account name from what was used in DUBBD to UDS-CORE.

Fix the S3 bucket policy Principal to use the correct IaM role